### PR TITLE
Default installation typos

### DIFF
--- a/Resources/doc/INSTALL.md
+++ b/Resources/doc/INSTALL.md
@@ -22,7 +22,7 @@ Add the following to your composer.json and run `php composer.phar update netgen
 
 ### Activate the bundle
 
-Activate the bundle in `ezpublish\EzPublishKernel.php` file.
+Activate the bundle in `ezpublish/EzPublishKernel.php` file.
 
 ```php
 use Netgen\Bundle\EnhancedSelectionBundle\NetgenEnhancedSelectionBundle;

--- a/Resources/views/sckenhancedselection_content_field.html.twig
+++ b/Resources/views/sckenhancedselection_content_field.html.twig
@@ -1,4 +1,4 @@
-{% block ngclasslist_field %}
+{% block sckenhancedselection_field %}
 {% spaceless %}
     {% for identifier in field.value.identifiers %}
         {{ identifier }}{% if not loop.last %}, {% endif %}


### PR DESCRIPTION
Hello Netgen!

We wanted to take a moment to first thank you for your wonderful work with this dual kernel solution!

During the course of a normal share forum thread, BC found several small but serious problems when trying to use and guide a new ezpublish user through the process of leveraging your solution to solve their use case requirements. http://share.ez.no/forums/ez-publish-5-platform/select-class-attribute-option-values-ez-5.4

The first problem found was a template block name typo which made the default installation usage fail by default.

The second issue was a less serious but while building this pull request using a clean new installation we found that we tried to copy and paste a path for the bundle activation path in the installation instructions. We found the directory separator was reversed which meant we could not copy and paste this path to the `ezpublish/EzPublishKernel.php` file to activate the bundle on unix based systems.

This pull request solves both those issues. We hope that you agree and will merge our improvements!

Please let us know how this finds you.

Take it eZ!

Cheers,
Brookins Consulting
