### PR TITLE
Legacy feature support in new stack user siteaccess usage

### DIFF
--- a/Resources/doc/INSTALL.md
+++ b/Resources/doc/INSTALL.md
@@ -49,3 +49,20 @@ php ezpublish/console cache:clear
 ### Use the bundle
 
 You can now load and create content with `sckenhancedselection` field type.
+
+## Using the content field within your own custom template
+
+Add the following template code into your template:
+
+```twig
+{% if not ez_is_field_empty(content, "selection") %}
+      {{ez_render_field(content, "selection")}}
+{% else %}
+       Empty selection
+{% endif %}
+```
+
+Replaced the text: "selection" with your own contenttype field identifier text string as needed.
+
+Save these additions to your custom template and clear caches as required.
+

--- a/Resources/views/sckenhancedselection_content_field.html.twig
+++ b/Resources/views/sckenhancedselection_content_field.html.twig
@@ -1,7 +1,26 @@
 {% block sckenhancedselection_field %}
 {% spaceless %}
-    {% for identifier in field.value.identifiers %}
-        {{ identifier }}{% if not loop.last %}, {% endif %}
+
+{% set available_options = fieldSettings.options %}
+{% set identifiers = field.value.identifiers %}
+
+{% if fieldSettings.delimiter is not empty %}
+    {% set delimiter = fieldSettings.delimiter %}
+{% else %}
+    {% set delimiter = ', ' %}
+{% endif %}
+
+{% if available_options is not empty and identifiers is not empty %}
+    {% for option in available_options %}
+        {% if option.identifier in identifiers %}
+            {{ option.name }}{% if not loop.last %}{{ delimiter }}{% endif %}
+        {% endif %}
     {% endfor %}
+{% elseif identifiers is not empty %}
+    {% for identifier in identifiers %}
+        {{ identifier }}{% if not loop.last %}{{ delimiter }}{% endif %}
+    {% endfor %}
+{% endif %}
+
 {% endspaceless %}
 {% endblock %}


### PR DESCRIPTION
Hello Netgen!

We again thank you for your fantastic solution! We took a moment to continue the work we started in https://github.com/netgen/NetgenEnhancedSelectionBundle/pull/1

This pull request depends on https://github.com/netgen/NetgenEnhancedSelectionBundle/pull/1 being merged first. Please merge the first pull request and then consider merging this pull request.

During the course of a normal share forum thread, http://share.ez.no/forums/ez-publish-5-platform/select-class-attribute-option-values-ez-5.4

We found several inconsistencies between the default legacy template feature support and the current new stack feature support. Basically the current new stack template can only display selected option identifiers and not the selected option names. I think we can agree that displaying option names is much more user friendly than only identifiers.

In general template logic (and underlying features) were quite different and also did not support the use of custom delimiter display.

The reason for the original limitations in the provided bundle was because the provided FieldType FieldValue Converter was so basic it did not provide support for the use of FieldSettings to the template layer with the stored ContentType Field settings.

In general we borrowed code and syntax for these additions for the default selection FieldType as a guide and customized provided FieldType FieldValue Converter using the legacy datatype's features (but not syntax) also as a guide (as required; not needed).

We have extended the solution in general to provide the same default user siteaccess features as legacy. We think this represents a substantial improvement to the new stack bundle that all user can benefit from, right out of the box! And while we have not ported all features of the legacy datatype specifically since eZ Platform UI is still alpha and feature incomplete (in terms of Content Type definition administration)... we think that our improvements provide a solid basis for current users trying to get the same features provided by the legacy datatype's default use provided feature set in a user siteaccess context and future developers extending the solution further (when eZ Platform UI does provide for Content Type definition administration).

This pull request solves issues surrounding different default use feature support. 

We hope that you agree and will merge our improvements!

Note: This is our very first attempt at custom FieldType and Twig template bundle improvements based on legacy datatype and eztpl features. _Please be gentle if we have made any errors or omissions_ :)

Please let us know how this finds you.

Take it eZ!

Cheers,
Brookins Consulting
:octocat:
