### PR TITLE
Add default support for sorting options by priority

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,0 +1,16 @@
+COPYRIGHT NOTICE: Copyright (C) 2014-2015 Netgen and Brookins Consulting
+SOFTWARE LICENSE: GNU General Public License v2.0
+NOTICE: >
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of version 2.0 of the GNU General
+  Public License as published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of version 2.0 of the GNU General
+  Public License along with this program; if not, write to the Free
+  Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+  MA 02110-1301, USA.

--- a/Resources/config/storage_engines.yml
+++ b/Resources/config/storage_engines.yml
@@ -1,8 +1,13 @@
 parameters:
     ezpublish.fieldType.sckenhancedselection.converter.class: Netgen\Bundle\EnhancedSelectionBundle\Core\Persistence\Legacy\Content\FieldValue\Converter\EnhancedSelectionConverter
+    ezpublish.twig.twig_extension.enhancedselection_sort.class: Netgen\Bundle\EnhancedSelectionBundle\Twig\Extension\EnhancedSelectionSortExtension
 
 services:
     ezpublish.fieldType.sckenhancedselection.converter:
         class: %ezpublish.fieldType.sckenhancedselection.converter.class%
         tags:
             - {name: ezpublish.storageEngine.legacy.converter, alias: sckenhancedselection, lazy: true, callback: "::create"}
+    ezpublish.twig.twig_extension.enhancedselection_sort:
+        class:  %ezpublish.twig.twig_extension.enhancedselection_sort.class%
+        tags:
+            - { name: twig.extension }

--- a/Resources/doc/INSTALL.md
+++ b/Resources/doc/INSTALL.md
@@ -65,3 +65,43 @@ Add the following template code into your template:
 Replace the text: "selection" with your own content type field identifier as needed.
 
 Save these additions to your custom template and clear caches as required.
+
+Custom usage
+------------------
+
+### Custom content_field template override
+
+PrependExtensionInterface should be used instead
+
+Then create a copy of the default `sckenhancedselection_content_field.html.twig` template into your activated custom, and customize as needed and then clear cache.
+
+Edit your `ezpublish/config/config.yml` file, add and customize the following yaml configuration:
+
+```yaml
+parameters:
+    ezsettings.YOUR_SITEACCESS_NAME.field_templates:
+          -  {template: EzPublishCoreBundle::content_fields.html.twig, priority: 0}
+          -  {template: YourCustomDesignTemplateBundle::sckenhancedselection_content_field.html.twig, priority: 0}
+```
+
+Then create a copy of the default `sckenhancedselection_content_field.html.twig` template into your activated custom bundle and customize as needed.
+
+### Controling the selection options display order
+
+* The default sorting of enhanced selection options requires unique numeric selection option priority values otherwise the order they are created is used
+
+### Sort selection options by any other selection option field besides priority
+
+The default display order of enhanced selection options is by priority. Other sort orders supported by default are: id, identifier and name.
+
+You can sort your selection options display order by any other selection option field besides priority by creating a `sckenhancedselection_content_field.html.twig` template override (described above).
+
+Then edit the `sckenhancedselection_content_field.html.twig` template in your custom bundle and changing the twig filter 'sort_by_selection_field' first parameter (sortByField), a string, 'priority' to any one of the following values supported by default.
+
+The twig filter 'sort_by_selection_field' provided by this extension uses the php function 'usort' and a custom 'usort value_compare_func' to sort selection options.
+
+The twig filter 'sort_by_selection_field' will not sort selection options by 'priority' if the FieldType options 'priority' field values contain duplicate values.
+
+By default each time you create an enhanced selection option the default priority is set to 1. This is historically due to a bug in the legacy datatype where each time a new option is created the priority is set to 1 even if another option with priority of 1 already exists.
+
+If you do not manually edit your enhanced selection options priority values to be unique then the default order, the order they were created is the order they will be displayed.

--- a/Resources/views/sckenhancedselection_content_field.html.twig
+++ b/Resources/views/sckenhancedselection_content_field.html.twig
@@ -1,7 +1,7 @@
 {% block sckenhancedselection_field %}
 {% spaceless %}
 
-{% set available_options = fieldSettings.options %}
+{% set available_options = fieldSettings.options|sckenhancedselection_sort( 'priority', 'asc' ) %}
 {% set identifiers = field.value.identifiers %}
 
 {% if fieldSettings.delimiter is not empty %}

--- a/Twig/Extension/EnhancedSelectionSortExtension.php
+++ b/Twig/Extension/EnhancedSelectionSortExtension.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * File containing the EnhancedSelectionSortExtension class.
+ *
+ * @copyright Copyright (C) Brookins Consulting. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace Netgen\Bundle\EnhancedSelectionBundle\Twig\Extension;
+
+use Twig_Extension;
+use Twig_SimpleFilter;
+use InvalidArgumentException;
+
+/**
+ * Twig extension providing the 'sckenhancedselection_sort' twig filter
+ */
+class EnhancedSelectionSortExtension extends Twig_Extension
+{
+    /**
+     * The "sckenhancedselection_sort" twig filter sorts an array of items ( objects or arrays ) by the specified sort by field value
+     *
+     * Usage: {% set available_options = options|sckenhancedselection_sort( 'priority', 'desc' ) %}
+     *
+     * @return array The array of Twig_SimpleFilter objects
+     */
+    public function getFilters()
+    {
+        return array(
+            new Twig_SimpleFilter( 'sckenhancedselection_sort', array( $this, 'sortByEnhancedSelectionOptionField' ) )
+        );
+    }
+
+    /**
+     * The "sortByEnhancedSelectionOptionField" method sorts an array of items by the specified sort by field value
+     * if the available options priority values do not contain duplicates which returns the options without modifications
+     *
+     * @param array $content  Array of selection options
+     * @param string $sortByField  String of selection sort field. Supports: priority|id|identifier|name. Default: priority
+     * @param string $sortDirection  String of selection sort direction. Supports: asc|desc. Default: asc
+     *
+     * @return array The array of FieldType selection options sorted as best as possible
+     */
+    public function sortByEnhancedSelectionOptionField( $content, $sortByField = 'priority', $sortDirection = 'asc' )
+    {
+        $selection_options_field_content_not_sortable = false;
+
+        if( !is_array( $content ) )
+        {
+            throw new InvalidArgumentException( 'Input passed to sckenhancedselection_sort twig filter is not an array' );
+        }
+        else if ( $sortByField === null )
+        {
+            throw new InvalidArgumentException( 'Sort by field parameter passed to the sckenhancedselection_sort twig filter can not be null' );
+        }
+        else if ( !isset( $content[ 0 ][ $sortByField ] ) )
+        {
+            throw new InvalidArgumentException( 'Sort by field parameter passed to the sckenhancedselection_sort twig filter must be either: priority, id, identifier or name' );
+        }
+        else
+        {
+            for( $i = 0, $j = 0, $n = count( $content ); $i < $n; ++$i )
+            {
+                for( $g = $i + 1; $g < $n; ++$g )
+                {
+                    if( $content[ $i ][ $sortByField ] == $content[ $g ][ $sortByField ] )
+                    {
+                        $selection_options_field_content_not_sortable = true;
+                    }
+                }
+
+                if( $selection_options_field_content_not_sortable == true )
+                {
+                    break;
+                }
+            }
+
+            if( $selection_options_field_content_not_sortable == false )
+            {
+                usort( $content, self::usortByPriority( $sortByField, $sortDirection ) );
+            }
+        }
+
+        return $content;
+    }
+
+    /**
+     * Provides usort value_compare_func function to sort selection options
+     *
+     * @return int The usort value_compare_func function result to determin sort order
+     */
+    public function usortByPriority( $sortByField = 'priority', $sortDirection = 'asc' )
+    {
+        return function ( $a, $b ) use ( $sortByField, $sortDirection )
+        {
+            $sortDirectionInt = $sortDirection === 'desc' ? -1 : 1;
+
+            if ( $a[ $sortByField ] == $b[ $sortByField ] )
+            {
+                return 0;
+            }
+            elseif ( $a[ $sortByField ] > $b[ $sortByField ] )
+            {
+                return ( 1 * $sortDirectionInt );
+            }
+            else
+            {
+                return ( -1 * $sortDirectionInt );
+            }
+        };
+    }
+
+    /**
+     * Returns the name of the twig extension.
+     *
+     * @return string The twig extension name
+     */
+    public function getName()
+    {
+        return 'sckenhancedselection_sort';
+    }
+}


### PR DESCRIPTION
Hello Netgen!

Per our idea in our previous [PR#2](https://github.com/netgen/NetgenEnhancedSelectionBundle/pull/2#issuecomment-98437111) we have added default support for sorting enhanced selection options by enhanced selection option priority (or any other enhanced selection option field value).

This PR depends on our previous PR #2 being merged first.

This PR provides detailed documentation on making use and customization of the sorting feature as well as copyright and license documentation. This PR has been thoroughly tested with nearly every possible used case provided by the default legacy datatype implementation.

We based the priority sorting feature on the data and features provided by the legacy datatype.

We implemented these features today in the twig layer to provide for developer customization of the sort order field and direction. At a later time when ezplatformUI provides for ContentType definition it may be more user friendly to alter the FieldType implementation to provide an additional option to control the sort order directly, thus deprecating this solution. Until that time, this solution provides a useful feature provided by the legacy datatype implementation which can easily be unused, removed or customized as needed.

Please let us know what you think of these improvements.

Thank you for your continued support!

Cheers,
Brookins Consulting 
