### PR TITLE
enable basic indexing for fieldtype data

### DIFF
--- a/Core/FieldType/EnhancedSelection/SearchField.php
+++ b/Core/FieldType/EnhancedSelection/SearchField.php
@@ -31,17 +31,17 @@ class SearchField implements Indexable
 
         return [
             new Search\Field(
-                'enhanced_selection_identifiers',
+                'identifiers',
                 $selectionKeys,
                 new Search\FieldType\MultipleStringField()
             ),
             new Search\Field(
-                'enhanced_selection_ids',
+                'ids',
                 $selectionIds,
                 new Search\FieldType\MultipleIntegerField()
             ),
             new Search\Field(
-                'enhanced_selection_text',
+                'names',
                 implode(' ', $selectionNames),
                 new Search\FieldType\TextField()
             ),
@@ -60,9 +60,9 @@ class SearchField implements Indexable
     public function getIndexDefinition()
     {
         return [
-            'enhanced_selection_identifiers' => new Search\FieldType\MultipleStringField(),
-            'enhanced_selection_ids' => new Search\FieldType\MultipleIntegerField(),
-            'enhanced_selection_text' => new Search\FieldType\TextField(),
+            'identifiers' => new Search\FieldType\MultipleStringField(),
+            'ids' => new Search\FieldType\MultipleIntegerField(),
+            'names' => new Search\FieldType\TextField(),
             'fulltext' => new Search\FieldType\FullTextField(),
         ];
     }
@@ -73,7 +73,7 @@ class SearchField implements Indexable
      */
     public function getDefaultMatchField()
     {
-        return 'enhanced_selection_identifiers';
+        return 'identifiers';
     }
     /**
      * Get name of the default field to be used for sorting.

--- a/Core/FieldType/EnhancedSelection/SearchField.php
+++ b/Core/FieldType/EnhancedSelection/SearchField.php
@@ -1,9 +1,11 @@
 <?php
 namespace Netgen\Bundle\EnhancedSelectionBundle\Core\FieldType\EnhancedSelection;
+
 use eZ\Publish\SPI\Persistence\Content\Field;
 use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\SPI\FieldType\Indexable;
 use eZ\Publish\SPI\Search;
+
 class SearchField implements Indexable
 {
     /**
@@ -26,6 +28,7 @@ class SearchField implements Indexable
                 $selectionNames[] = $option['name'];
             }
         }
+
         return [
             new Search\Field(
                 'enhanced_selection_identifiers',

--- a/Core/FieldType/EnhancedSelection/SearchField.php
+++ b/Core/FieldType/EnhancedSelection/SearchField.php
@@ -1,0 +1,84 @@
+<?php
+namespace Netgen\Bundle\EnhancedSelectionBundle\Core\FieldType\EnhancedSelection;
+use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
+use eZ\Publish\SPI\FieldType\Indexable;
+use eZ\Publish\SPI\Search;
+class SearchField implements Indexable
+{
+    /**
+     * Get index data for field for search backend.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
+     *
+     * @return \eZ\Publish\SPI\Search\Field[]
+     */
+    public function getIndexData(Field $field, FieldDefinition $fieldDefinition)
+    {
+        $selectionKeys = (array)$field->value->externalData;
+        $selectionIds = [];
+        $selectionNames = [];
+
+        foreach ($fieldDefinition->fieldTypeConstraints->fieldSettings['options'] as $option) {
+            if (in_array($option['identifier'], $selectionKeys)) {
+                $selectionIds[] = $option['id'];
+                $selectionNames[] = $option['name'];
+            }
+        }
+        return [
+            new Search\Field(
+                'enhanced_selection_identifiers',
+                $selectionKeys,
+                new Search\FieldType\MultipleStringField()
+            ),
+            new Search\Field(
+                'enhanced_selection_ids',
+                $selectionIds,
+                new Search\FieldType\MultipleIntegerField()
+            ),
+            new Search\Field(
+                'enhanced_selection_text',
+                implode(' ', $selectionNames),
+                new Search\FieldType\TextField()
+            ),
+            new Search\Field(
+                'fulltext',
+                implode(' ', $selectionNames),
+                new Search\FieldType\FullTextField()
+            ),
+        ];
+    }
+    /**
+     * Get index field types for search backend.
+     *
+     * @return \eZ\Publish\SPI\Search\FieldType[]
+     */
+    public function getIndexDefinition()
+    {
+        return [
+            'enhanced_selection_identifiers' => new Search\FieldType\MultipleStringField(),
+            'enhanced_selection_ids' => new Search\FieldType\MultipleIntegerField(),
+            'enhanced_selection_text' => new Search\FieldType\TextField(),
+            'fulltext' => new Search\FieldType\FullTextField(),
+        ];
+    }
+    /**
+     * Get name of the default field to be used for matching.
+     *
+     * @return string
+     */
+    public function getDefaultMatchField()
+    {
+        return 'enhanced_selection_identifiers';
+    }
+    /**
+     * Get name of the default field to be used for sorting.
+     *
+     * @return string
+     */
+    public function getDefaultSortField()
+    {
+        return $this->getDefaultMatchField();
+    }
+}

--- a/Resources/config/fieldtypes.yml
+++ b/Resources/config/fieldtypes.yml
@@ -1,7 +1,7 @@
 parameters:
     ezpublish.fieldType.sckenhancedselection.class: Netgen\Bundle\EnhancedSelectionBundle\Core\FieldType\EnhancedSelection\Type
     ezpublish.fieldType.sckenhancedselection.externalStorage.class: Netgen\Bundle\EnhancedSelectionBundle\Core\FieldType\EnhancedSelection\EnhancedSelectionStorage
-    ezpublish.fieldType.indexable.sckenhancedselection.class: eZ\Publish\Core\FieldType\Unindexed
+    ezpublish.fieldType.indexable.sckenhancedselection.class: Netgen\Bundle\EnhancedSelectionBundle\Core\FieldType\EnhancedSelection\SearchField
     ezpublish.fieldType.form.fieldtype_handler.sckenhancedselection.class: Netgen\Bundle\EnhancedSelectionBundle\Form\FieldTypeHandler\EnhancedSelection
 
 services:


### PR DESCRIPTION
This PR is to allow indexing of the field data.  The keys, values, and ids of the selected options will be stored in solr.
