### PR TITLE
Twig function for fetching Selection name by selection identifier

### DIFF
--- a/DependencyInjection/NetgenEnhancedSelectionExtension.php
+++ b/DependencyInjection/NetgenEnhancedSelectionExtension.php
@@ -23,6 +23,7 @@ class NetgenEnhancedSelectionExtension extends Extension implements PrependExten
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('fieldtypes.yml');
         $loader->load('storage_engines.yml');
+        $loader->load('templating.yml');
 
         if ($container->hasParameter('ezpublish.persistence.legacy.search.gateway.sort_clause_handler.common.field.class')) {
             $loader->load('search.yml');

--- a/Resources/config/templating.yml
+++ b/Resources/config/templating.yml
@@ -1,0 +1,10 @@
+parameters:
+    netgen.enhanced_selection.templating.twig.extension.class: Netgen\Bundle\EnhancedSelectionBundle\Templating\Twig\NetgenEnhancedSelectionExtension
+
+services:
+    netgen.enhanced_selection.templating.twig.extension:
+        class: '%netgen.enhanced_selection.templating.twig.extension.class%'
+        arguments:
+            - '@ezpublish.api.service.content_type'
+        tags:
+            - { name: twig.extension }

--- a/Resources/config/templating.yml
+++ b/Resources/config/templating.yml
@@ -6,5 +6,6 @@ services:
         class: '%netgen.enhanced_selection.templating.twig.extension.class%'
         arguments:
             - '@ezpublish.api.service.content_type'
+            - '@ezpublish.translation_helper'
         tags:
             - { name: twig.extension }

--- a/Templating/Twig/NetgenEnhancedSelectionExtension.php
+++ b/Templating/Twig/NetgenEnhancedSelectionExtension.php
@@ -58,6 +58,7 @@ class NetgenEnhancedSelectionExtension extends Twig_Extension
     public function getSelectionName(Content $content, $fieldDefIdentifier, $selectionIdentifier = null)
     {
         $names = null;
+        $identifiers = array($selectionIdentifier);
 
         if (is_null($selectionIdentifier)) {
             $field = $this->translationHelper->getTranslatedField($content, $fieldDefIdentifier);
@@ -68,19 +69,16 @@ class NetgenEnhancedSelectionExtension extends Twig_Extension
             $content->contentInfo->contentTypeId
         );
 
+        $fieldDefinition = $contentType->getFieldDefinition($fieldDefIdentifier);
 
-        $fieldDefinitions = $contentType->fieldDefinitions;
-
-        foreach ($fieldDefinitions as $fieldDefinition) {
-            if ($fieldDefinition->identifier === $fieldDefIdentifier) {
-                foreach ($fieldDefinition->fieldSettings['options'] as $option) {
-                    if (is_null($selectionIdentifier) && in_array($option['identifier'], $identifiers)) {
-                        $names[$option['identifier']] = $option['name'];
-                    } else if (!is_null($selectionIdentifier) && $option['identifier'] === $selectionIdentifier) {
-                        return $option['name'];
-                    }
-                }
+        foreach ($fieldDefinition->fieldSettings['options'] as $option) {
+            if (in_array($option['identifier'], $identifiers)) {
+                $names[$option['identifier']] = $option['name'];
             }
+        }
+
+        if (!is_null($selectionIdentifier)) {
+            return !empty($names) ? $names[$selectionIdentifier] : null;
         }
 
         return $names;

--- a/Templating/Twig/NetgenEnhancedSelectionExtension.php
+++ b/Templating/Twig/NetgenEnhancedSelectionExtension.php
@@ -82,9 +82,9 @@ class NetgenEnhancedSelectionExtension extends \Twig_Extension
             if ($fieldDefinition->identifier === $fieldDefIdentifier) {
                 foreach ($fieldDefinition->fieldSettings['options'] as $option) {
                     if (!is_null($selectionIdentifier) && $option['identifier'] === $selectionIdentifier) {
-                        return array($option['name']);
+                        return array($option['identifier'] => $option['name']);
                     } else if (in_array($option['identifier'], $identifiers)) {
-                        $names[] = $option['name'];
+                        $names[$option['identifier']] = $option['name'];
                     }
                 }
             }

--- a/Templating/Twig/NetgenEnhancedSelectionExtension.php
+++ b/Templating/Twig/NetgenEnhancedSelectionExtension.php
@@ -53,24 +53,20 @@ class NetgenEnhancedSelectionExtension extends Twig_Extension
      * @param string $fieldDefIdentifier
      * @param null|string $selectionIdentifier
      *
-     * @return array|string
+     * @return array|string|null
      */
     public function getSelectionName(Content $content, $fieldDefIdentifier, $selectionIdentifier = null)
     {
-        $names = array();
+        $names = null;
 
-        if (empty($selectionIdentifier)) {
+        if (is_null($selectionIdentifier)) {
             $field = $this->translationHelper->getTranslatedField($content, $fieldDefIdentifier);
             $identifiers = $field->value->identifiers;
         }
 
-        try {
-            $contentType = $this->contentTypeService->loadContentType(
-                $content->contentInfo->contentTypeId
-            );
-        } catch (NotFoundException $e) {
-            return $names;
-        }
+       $contentType = $this->contentTypeService->loadContentType(
+            $content->contentInfo->contentTypeId
+        );
 
 
         $fieldDefinitions = $contentType->fieldDefinitions;
@@ -78,10 +74,10 @@ class NetgenEnhancedSelectionExtension extends Twig_Extension
         foreach ($fieldDefinitions as $fieldDefinition) {
             if ($fieldDefinition->identifier === $fieldDefIdentifier) {
                 foreach ($fieldDefinition->fieldSettings['options'] as $option) {
-                    if (!is_null($selectionIdentifier) && $option['identifier'] === $selectionIdentifier) {
-                        return $option['name'];
-                    } else if (in_array($option['identifier'], $identifiers)) {
+                    if (is_null($selectionIdentifier) && in_array($option['identifier'], $identifiers)) {
                         $names[$option['identifier']] = $option['name'];
+                    } else if (!is_null($selectionIdentifier) && $option['identifier'] === $selectionIdentifier) {
+                        return $option['name'];
                     }
                 }
             }

--- a/Templating/Twig/NetgenEnhancedSelectionExtension.php
+++ b/Templating/Twig/NetgenEnhancedSelectionExtension.php
@@ -3,6 +3,7 @@
 namespace Netgen\Bundle\EnhancedSelectionBundle\Templating\Twig;
 
 use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 use eZ\Publish\Core\Helper\TranslationHelper;
 use eZ\Publish\API\Repository\Values\Content\Content;
@@ -68,10 +69,18 @@ class NetgenEnhancedSelectionExtension extends \Twig_Extension
 
         }
 
+        try {
 
-        $contentType = $this->contentTypeService->loadContentType(
-            $content->contentInfo->contentTypeId
-        );
+            $contentType = $this->contentTypeService->loadContentType(
+                $content->contentInfo->contentTypeId
+            );
+
+        } catch (NotFoundException $e) {
+
+            return $names;
+
+        }
+
 
         $fieldDefinitions = $contentType->fieldDefinitions;
 

--- a/Templating/Twig/NetgenEnhancedSelectionExtension.php
+++ b/Templating/Twig/NetgenEnhancedSelectionExtension.php
@@ -63,22 +63,16 @@ class NetgenEnhancedSelectionExtension extends \Twig_Extension
         $names = array();
 
         if (empty($selectionIdentifier)) {
-
             $field = $this->translationHelper->getTranslatedField($content, $fieldDefIdentifier);
             $identifiers = $field->value->identifiers;
-
         }
 
         try {
-
             $contentType = $this->contentTypeService->loadContentType(
                 $content->contentInfo->contentTypeId
             );
-
         } catch (NotFoundException $e) {
-
             return $names;
-
         }
 
 
@@ -86,19 +80,12 @@ class NetgenEnhancedSelectionExtension extends \Twig_Extension
 
         foreach ($fieldDefinitions as $fieldDefinition) {
             if ($fieldDefinition->identifier === $fieldDefIdentifier) {
-
                 foreach ($fieldDefinition->fieldSettings['options'] as $option) {
-
                     if (!is_null($selectionIdentifier) && $option['identifier'] === $selectionIdentifier) {
-
                         return array($option['name']);
-
                     } else if (in_array($option['identifier'], $identifiers)) {
-
                         $names[] = $option['name'];
-
                     }
-
                 }
             }
         }

--- a/Templating/Twig/NetgenEnhancedSelectionExtension.php
+++ b/Templating/Twig/NetgenEnhancedSelectionExtension.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Netgen\Bundle\EnhancedSelectionBundle\Templating\Twig;
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo;
+use Netgen\Bundle\EnhancedSelectionBundle\Core\FieldType\EnhancedSelection\Value;
+
+/**
+ * Class NetgenEnhancedSelectionExtension
+ * @package Netgen\Bundle\EnhancedSelectionBundle\Templating\Twig
+ */
+class NetgenEnhancedSelectionExtension extends \Twig_Extension
+{
+    /**
+     * @var ContentTypeService
+     */
+    protected $contentTypeService;
+
+    /**
+     * NetgenEnhancedSelectionExtension constructor.
+     *
+     * @param ContentTypeService $contentTypeService
+     */
+    public function __construct(ContentTypeService $contentTypeService)
+    {
+        $this->contentTypeService = $contentTypeService;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getFunctions()
+    {
+        return array(
+            new \Twig_SimpleFunction(
+                'netgen_enhanced_selection_name',
+                array($this, 'getSelectionName')
+            ),
+        );
+    }
+
+    /**
+     * Returns selection name by given identifier
+     *
+     * @param Value $value
+     * @param VersionInfo $versionInfo
+     * @param string $fieldDefIdentifier
+     *
+     * @return string
+     */
+    public function getSelectionName(Value $value, VersionInfo $versionInfo, $fieldDefIdentifier)
+    {
+        $contentType = $this->contentTypeService->loadContentType(
+            $versionInfo->contentInfo->contentTypeId
+        );
+
+        $fieldDefinitions = $contentType->fieldDefinitions;
+
+        foreach ($fieldDefinitions as $fieldDefinition) {
+            if ($fieldDefinition->identifier === $fieldDefIdentifier) {
+
+                foreach ($fieldDefinition->fieldSettings['options'] as $option) {
+
+                    if ($option['identifier'] === $value->identifiers[0]) {
+                        return $option['name'];
+                    }
+
+                }
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * Returns the name of the extension.
+     *
+     * @return string The extension name
+     */
+    public function getName()
+    {
+        return 'netgen_enhanced_selection';
+    }
+}

--- a/Templating/Twig/NetgenEnhancedSelectionExtension.php
+++ b/Templating/Twig/NetgenEnhancedSelectionExtension.php
@@ -4,32 +4,28 @@ namespace Netgen\Bundle\EnhancedSelectionBundle\Templating\Twig;
 
 use eZ\Publish\API\Repository\ContentTypeService;
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
-use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 use eZ\Publish\Core\Helper\TranslationHelper;
 use eZ\Publish\API\Repository\Values\Content\Content;
-use Netgen\Bundle\EnhancedSelectionBundle\Core\FieldType\EnhancedSelection\Value;
+use Twig_SimpleFunction;
+use Twig_Extension;
 
-/**
- * Class NetgenEnhancedSelectionExtension
- * @package Netgen\Bundle\EnhancedSelectionBundle\Templating\Twig
- */
-class NetgenEnhancedSelectionExtension extends \Twig_Extension
+class NetgenEnhancedSelectionExtension extends Twig_Extension
 {
     /**
-     * @var ContentTypeService
+     * @var \eZ\Publish\API\Repository\ContentTypeService
      */
     protected $contentTypeService;
 
     /**
-     * @var TranslationHelper
+     * @var \eZ\Publish\Core\Helper\TranslationHelper
      */
     protected $translationHelper;
 
     /**
      * NetgenEnhancedSelectionExtension constructor.
      *
-     * @param ContentTypeService $contentTypeService
-     * @param TranslationHelper $translationHelper
+     * @param \eZ\Publish\API\Repository\ContentTypeService $contentTypeService
+     * @param \eZ\Publish\Core\Helper\TranslationHelper $translationHelper
      */
     public function __construct(ContentTypeService $contentTypeService, TranslationHelper $translationHelper)
     {
@@ -43,7 +39,7 @@ class NetgenEnhancedSelectionExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            new \Twig_SimpleFunction(
+            new Twig_SimpleFunction(
                 'netgen_enhanced_selection_name',
                 array($this, 'getSelectionName')
             ),
@@ -53,10 +49,11 @@ class NetgenEnhancedSelectionExtension extends \Twig_Extension
     /**
      * Returns selection names
      *
-     * @param Content $content
+     * @param \eZ\Publish\API\Repository\Values\Content\Content $content
      * @param string $fieldDefIdentifier
      * @param null|string $selectionIdentifier
-     * @return array
+     *
+     * @return array|string
      */
     public function getSelectionName(Content $content, $fieldDefIdentifier, $selectionIdentifier = null)
     {
@@ -82,7 +79,7 @@ class NetgenEnhancedSelectionExtension extends \Twig_Extension
             if ($fieldDefinition->identifier === $fieldDefIdentifier) {
                 foreach ($fieldDefinition->fieldSettings['options'] as $option) {
                     if (!is_null($selectionIdentifier) && $option['identifier'] === $selectionIdentifier) {
-                        return array($option['identifier'] => $option['name']);
+                        return $option['name'];
                     } else if (in_array($option['identifier'], $identifiers)) {
                         $names[$option['identifier']] = $option['name'];
                     }

--- a/Tests/Templating/Twig/NetgenEnhancedSelectionExtensionTest.php
+++ b/Tests/Templating/Twig/NetgenEnhancedSelectionExtensionTest.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace Netgen\Bundle\EnhancedSelectionBundle\Tests\Templating\Twig;
+
+use eZ\Publish\Core\Base\Exceptions\NotFoundException;
+use eZ\Publish\Core\Helper\TranslationHelper;
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\Core\Repository\Values\Content\Content;
+use eZ\Publish\Core\Repository\Values\ContentType\ContentType;
+use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
+use eZ\Publish\Core\Repository\Values\ContentType\FieldDefinition;
+use eZ\Publish\SPI\Persistence\Content\ContentInfo;
+use eZ\Publish\SPI\Persistence\Content\Field;
+use Netgen\Bundle\EnhancedSelectionBundle\Core\FieldType\EnhancedSelection\Value;
+use Netgen\Bundle\EnhancedSelectionBundle\Templating\Twig\NetgenEnhancedSelectionExtension;
+
+class NetgenEnhancedSelectionExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var NetgenEnhancedSelectionExtension
+     */
+    protected $extension;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $translationHelper;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $contentTypeService;
+
+    public function setUp()
+    {
+        $this->translationHelper = $this->getMockBuilder(TranslationHelper::class)
+            ->disableOriginalConstructor()
+            ->setMethods(array('getTranslatedField'))
+            ->getMock();
+
+        $this->contentTypeService = $this->getMockBuilder(ContentTypeService::class)
+            ->disableOriginalConstructor()
+            ->setMethods(array('loadContentType'))
+            ->getMockForAbstractClass();
+
+        $this->extension = new NetgenEnhancedSelectionExtension($this->contentTypeService, $this->translationHelper);
+    }
+
+    public function testInstanceOfTwigExtension()
+    {
+        $this->assertInstanceOf(\Twig_Extension::class, $this->extension);
+    }
+
+    public function testGetName()
+    {
+        $this->assertEquals('netgen_enhanced_selection', $this->extension->getName());
+    }
+
+
+    public function testGetFunctions()
+    {
+        $functions = array(
+            new \Twig_SimpleFunction(
+                'netgen_enhanced_selection_name',
+                array($this->extension, 'getSelectionName')
+            ),
+        );
+
+        $result = $this->extension->getFunctions();
+
+        $this->assertEquals($functions, $result);
+    }
+
+    public function testGetSelectionName()
+    {
+        $fieldIdentifier = 'some_field';
+        $contentInfo = new ContentInfo(array('contentTypeId' => 12345));
+
+        $versionInfo = new VersionInfo(array('contentInfo' => $contentInfo));
+
+        $content = new Content(array('versionInfo' => $versionInfo));
+
+        $selectionValue = new Value(array('some_name', 'some_name_2'));
+        $field = new Field(array('value' => $selectionValue));
+
+        $this->translationHelper->expects($this->once())
+            ->method('getTranslatedField')
+            ->with($content, $fieldIdentifier)
+            ->willReturn($field);
+
+        $fieldSettings = array(
+            'options' => array(
+                array(
+                    'id' => 1,
+                    'name' => 'Some name',
+                    'identifier' => 'some_name',
+                    'priority' => 1,
+                ),
+                array(
+                    'id' => 2,
+                    'name' => 'Some name 2',
+                    'identifier' => 'some_name_2',
+                    'priority' => 1,
+                ),
+            ),
+        );
+
+        $fieldDefinition = new FieldDefinition(
+            array(
+                'identifier' => $fieldIdentifier,
+                'fieldSettings' => $fieldSettings,
+            )
+        );
+
+        $contentType = new ContentType(array('fieldDefinitions' => array($fieldDefinition)));
+
+        $this->contentTypeService->expects($this->once())
+            ->method('loadContentType')
+            ->with($content->contentInfo->contentTypeId)
+            ->willReturn($contentType);
+
+        $result = $this->extension->getSelectionName($content, $fieldIdentifier);
+
+        $this->assertTrue(is_array($result));
+
+        $expectedResult = array(
+            'some_name' => 'Some name',
+            'some_name_2' => 'Some name 2',
+        );
+
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    public function testGetSelectionNameBySpecifiedIdentifier()
+    {
+        $fieldIdentifier = 'some_field';
+        $contentInfo = new ContentInfo(array('contentTypeId' => 12345));
+
+        $versionInfo = new VersionInfo(array('contentInfo' => $contentInfo));
+
+        $content = new Content(array('versionInfo' => $versionInfo));
+
+        $fieldSettings = array(
+            'options' => array(
+                array(
+                    'id' => 1,
+                    'name' => 'Some name',
+                    'identifier' => 'some_name',
+                    'priority' => 1,
+                ),
+                array(
+                    'id' => 2,
+                    'name' => 'Some name 2',
+                    'identifier' => 'some_name_2',
+                    'priority' => 1,
+                ),
+            ),
+        );
+
+        $fieldDefinition = new FieldDefinition(
+            array(
+                'identifier' => $fieldIdentifier,
+                'fieldSettings' => $fieldSettings,
+            )
+        );
+
+        $contentType = new ContentType(array('fieldDefinitions' => array($fieldDefinition)));
+
+        $this->contentTypeService->expects($this->once())
+            ->method('loadContentType')
+            ->with($content->contentInfo->contentTypeId)
+            ->willReturn($contentType);
+
+        $result = $this->extension->getSelectionName($content, $fieldIdentifier, 'some_name');
+
+        $this->assertTrue(is_array($result));
+
+        $expectedResult = array(
+            'some_name' => 'Some name',
+        );
+
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    public function testGetSelectionNameWithNotFoundException()
+    {
+        $fieldIdentifier = 'some_field';
+        $contentTypeId = '12345';
+
+        $contentInfo = new ContentInfo(array('contentTypeId' => $contentTypeId));
+
+        $versionInfo = new VersionInfo(array('contentInfo' => $contentInfo));
+
+        $content = new Content(array('versionInfo' => $versionInfo));
+
+        $selectionValue = new Value(array(1, 2, 3));
+        $field = new Field(array('value' => $selectionValue));
+
+        $this->translationHelper->expects($this->once())
+            ->method('getTranslatedField')
+            ->with($content, $fieldIdentifier)
+            ->willReturn($field);
+
+        $this->contentTypeService->expects($this->once())
+            ->method('loadContentType')
+            ->with($content->contentInfo->contentTypeId)
+            ->willThrowException(new NotFoundException('ContentType', $contentTypeId));
+
+        $result = $this->extension->getSelectionName($content, $fieldIdentifier);
+
+        $this->assertTrue(is_array($result));
+    }
+}

--- a/Tests/Templating/Twig/NetgenEnhancedSelectionExtensionTest.php
+++ b/Tests/Templating/Twig/NetgenEnhancedSelectionExtensionTest.php
@@ -173,13 +173,9 @@ class NetgenEnhancedSelectionExtensionTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->extension->getSelectionName($content, $fieldIdentifier, 'some_name');
 
-        $this->assertTrue(is_array($result));
+        $this->assertTrue(is_string($result));
 
-        $expectedResult = array(
-            'some_name' => 'Some name',
-        );
-
-        $this->assertEquals($expectedResult, $result);
+        $this->assertEquals('Some name', $result);
     }
 
     public function testGetSelectionNameWithNotFoundException()


### PR DESCRIPTION
Added Twig function _netgen_enhanced_selection_name_ which takes _Content_ and field identifier and returns associative array of identifiers and names.

Also, third argument can be provided which specifies Selection identifier and in this case function will return string name that matches specified identifier.
