### PR TITLE
Add ezplatform-solr-search-engine 1.2.0 to composer.json conflict section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "netgen/ez-forms-bundle": "Allows use of enhanced selection field type with Symfony forms"
     },
     "conflict": {
-        "netgen/enhancedselection2": "<2.0"
+        "netgen/enhancedselection2": "<2.0",
+        "ezsystems/ezplatform-solr-search-engine": "1.2.0"
     },
     "autoload": {
         "psr-4": { "Netgen\\Bundle\\EnhancedSelectionBundle\\": "" }


### PR DESCRIPTION
ezplatform-solr-search-engine for version 1.2.0 added to composer.json conflict section. For detailed info please check https://github.com/ezsystems/ezplatform-solr-search-engine/pull/85