### PR TITLE
NGGW-120: Implement language code for selection options

### DIFF
--- a/bundle/Core/FieldType/EnhancedSelection/FormMapper.php
+++ b/bundle/Core/FieldType/EnhancedSelection/FormMapper.php
@@ -30,6 +30,7 @@ final class FormMapper implements FieldDefinitionFormMapperInterface, FieldValue
                         [
                             'required' => $data->fieldDefinition->isRequired,
                             'label' => $data->fieldDefinition->getName(),
+                            'language_code' => $data->field->languageCode,
                             'field_definition' => $data->fieldDefinition,
                         ]
                     )

--- a/bundle/Core/FieldType/EnhancedSelection/Type.php
+++ b/bundle/Core/FieldType/EnhancedSelection/Type.php
@@ -267,9 +267,29 @@ final class Type extends FieldType
                                 }
                             }
 
+                            if (!isset($option['language_code'])) {
+                                $validationErrors[] = new ValidationError(
+                                    "'%setting%' setting value item must have a 'language_code' property",
+                                    null,
+                                    [
+                                        '%setting%' => $name,
+                                    ]
+                                );
+                            } else {
+                                if (!is_string($option['language_code'])) {
+                                    $validationErrors[] = new ValidationError(
+                                        "'%setting%' setting value item's 'language_code' property must be of string value",
+                                        null,
+                                        [
+                                            '%setting%' => $name,
+                                        ]
+                                    );
+                                }
+                            }
+
                             if (!isset($option['priority'])) {
                                 $validationErrors[] = new ValidationError(
-                                    "'%setting%' setting value item must have an 'priority' property",
+                                    "'%setting%' setting value item must have a 'priority' property",
                                     null,
                                     [
                                         '%setting%' => $name,

--- a/bundle/Core/Persistence/Legacy/Content/FieldValue/Converter/EnhancedSelectionConverter.php
+++ b/bundle/Core/Persistence/Legacy/Content/FieldValue/Converter/EnhancedSelectionConverter.php
@@ -48,6 +48,7 @@ final class EnhancedSelectionConverter implements Converter
                 $optionNode->setAttribute('id', (string) ($key + 1));
                 $optionNode->setAttribute('name', (string) $option['name']);
                 $optionNode->setAttribute('identifier', (string) $option['identifier']);
+                $optionNode->setAttribute('language_code', (string) $option['language_code']);
                 $optionNode->setAttribute('priority', (string) $option['priority']);
             }
         }
@@ -99,6 +100,7 @@ final class EnhancedSelectionConverter implements Converter
                         'id' => (int) $option['id'],
                         'name' => (string) $option['name'],
                         'identifier' => (string) $option['identifier'],
+                        'language_code' => (string) $option['language_code'],
                         'priority' => (int) $option['priority'],
                     ];
                 }

--- a/bundle/Form/Type/FieldType/EnhancedSelectionFieldType.php
+++ b/bundle/Form/Type/FieldType/EnhancedSelectionFieldType.php
@@ -24,28 +24,35 @@ final class EnhancedSelectionFieldType extends AbstractType
 
     public function configureOptions(OptionsResolver $resolver): void
     {
-        $resolver->setRequired(['field_definition']);
+        $resolver->setRequired(['field_definition', 'language_code']);
+
         $resolver->setAllowedTypes('field_definition', FieldDefinition::class);
+        $resolver->setAllowedTypes('language_code', 'string');
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         /** @var \Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition $fieldDefinition */
         $fieldDefinition = $options['field_definition'];
-        $options = $fieldDefinition->fieldSettings['options'];
+        $fieldOptions = $fieldDefinition->fieldSettings['options'];
+
+        /** @var string $languageCode */
+        $languageCode = $options['language_code'];
 
         usort(
-            $options,
+            $fieldOptions,
             static fn (array $option1, array $option2): int => $option2['priority'] <=> $option1['priority']
         );
 
         $choices = [];
-        foreach ($options as $option) {
-            if ($option['identifier'] === '' && $fieldDefinition->isRequired) {
+        foreach ($fieldOptions as $fieldOption) {
+            if ($fieldOption['identifier'] === '' && $fieldDefinition->isRequired) {
                 continue;
             }
 
-            $choices[$option['name']] = $option['identifier'];
+            if ($fieldOption['language_code'] === $languageCode || $fieldOption['language_code'] === '') {
+                $choices[$fieldOption['name']] = $fieldOption['identifier'];
+            }
         }
 
         $builder

--- a/bundle/Form/Type/FieldType/OptionType.php
+++ b/bundle/Form/Type/FieldType/OptionType.php
@@ -4,15 +4,33 @@ declare(strict_types=1);
 
 namespace Netgen\Bundle\EnhancedSelectionBundle\Form\Type\FieldType;
 
+use Generator;
+use Ibexa\Contracts\Core\Repository\LanguageService;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 final class OptionType extends AbstractType
 {
+    private LanguageService $languageService;
+
+    public function __construct(LanguageService $languageService)
+    {
+        $this->languageService = $languageService;
+    }
+
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
+        $languageCodeChoices = (function (): Generator {
+            yield 'field_definition.sckenhancedselection.settings.options.all_languages' => '';
+
+            foreach ($this->languageService->loadLanguages() as $language) {
+                yield $language->getName() => $language->languageCode;
+            }
+        })();
+
         $builder
             ->add(
                 'name',
@@ -29,6 +47,15 @@ final class OptionType extends AbstractType
                     'required' => false,
                     'empty_data' => '',
                     'label' => 'field_definition.sckenhancedselection.settings.options.identifier',
+                ]
+            )
+            ->add(
+                'language_code',
+                ChoiceType::class,
+                [
+                    'required' => false,
+                    'label' => 'field_definition.sckenhancedselection.settings.options.language_code',
+                    'choices' => $languageCodeChoices,
                 ]
             )
             ->add(

--- a/bundle/Resources/config/field_types.yaml
+++ b/bundle/Resources/config/field_types.yaml
@@ -44,3 +44,10 @@ services:
             - "@ibexa.api.service.field_type"
         tags:
             - { name: form.type }
+
+    netgen.enhanced_selection.field_type.form.option_type:
+        class: Netgen\Bundle\EnhancedSelectionBundle\Form\Type\FieldType\OptionType
+        arguments:
+            - "@ibexa.api.service.language"
+        tags:
+            - { name: form.type }

--- a/bundle/Resources/translations/content_type.en.yaml
+++ b/bundle/Resources/translations/content_type.en.yaml
@@ -1,6 +1,8 @@
 field_definition.sckenhancedselection.settings.options: 'Options'
+field_definition.sckenhancedselection.settings.options.all_languages: 'All languages'
 field_definition.sckenhancedselection.settings.options.name: 'Name'
 field_definition.sckenhancedselection.settings.options.identifier: 'Identifier'
+field_definition.sckenhancedselection.settings.options.language_code: 'Language code'
 field_definition.sckenhancedselection.settings.options.priority: 'Priority'
 field_definition.sckenhancedselection.settings.options.add_option: 'Add option'
 field_definition.sckenhancedselection.settings.is_multiple: 'Multiple'

--- a/bundle/Resources/views/field_definition/edit/macros.html.twig
+++ b/bundle/Resources/views/field_definition/edit/macros.html.twig
@@ -1,5 +1,5 @@
 {% macro option_prototype(form) %}
-    {% form_theme form '@NetgenEnhancedSelection/field_definition/edit/option_widget.twig' %}
+    {% form_theme form '@NetgenEnhancedSelection/field_definition/edit/option_widget.html.twig' %}
 
     <tr class="multientry-item">
         {{ form_widget(form) }}

--- a/bundle/Resources/views/field_definition/edit/option_widget.html.twig
+++ b/bundle/Resources/views/field_definition/edit/option_widget.html.twig
@@ -12,6 +12,11 @@
     </td>
 
     <td>
+        {{- form_errors(form.language_code) -}}
+        {{- form_widget(form.language_code) -}}
+    </td>
+
+    <td>
         {{- form_errors(form.priority) -}}
         {{- form_widget(form.priority) -}}
     </td>

--- a/bundle/Resources/views/field_definition/edit/sckenhancedselection.html.twig
+++ b/bundle/Resources/views/field_definition/edit/sckenhancedselection.html.twig
@@ -13,6 +13,7 @@
                     <tr>
                         <th>{{ 'field_definition.sckenhancedselection.settings.options.name'|trans }}</th>
                         <th>{{ 'field_definition.sckenhancedselection.settings.options.identifier'|trans }}</th>
+                        <th>{{ 'field_definition.sckenhancedselection.settings.options.language_code'|trans }}</th>
                         <th colspan="2">{{ 'field_definition.sckenhancedselection.settings.options.priority'|trans }}</th>
                     </tr>
                 </thead>

--- a/bundle/Resources/views/sckenhancedselection_content_field.html.twig
+++ b/bundle/Resources/views/sckenhancedselection_content_field.html.twig
@@ -14,7 +14,7 @@
     {% set options = [] %}
 
     {% for option in available_options %}
-        {% if option.identifier in identifiers %}
+        {% if option.identifier in identifiers and option.language_code in [field.languageCode, ''] %}
             {% set options = options|merge([option.name]) %}
         {% endif %}
     {% endfor %}

--- a/tests/Core/FieldType/EnhancedSelection/TypeTest.php
+++ b/tests/Core/FieldType/EnhancedSelection/TypeTest.php
@@ -241,7 +241,15 @@ final class TypeTest extends TestCase
         );
 
         $validationError3 = new ValidationError(
-            "'%setting%' setting value item must have an 'priority' property",
+            "'%setting%' setting value item must have a 'language_code' property",
+            null,
+            [
+                '%setting%' => 'options',
+            ]
+        );
+
+        $validationError4 = new ValidationError(
+            "'%setting%' setting value item must have a 'priority' property",
             null,
             [
                 '%setting%' => 'options',
@@ -258,6 +266,9 @@ final class TypeTest extends TestCase
 
         self::assertSame($validationError3->getTarget(), $errors[2]->getTarget());
         self::assertSame((string) $validationError3->getTranslatableMessage(), (string) $errors[2]->getTranslatableMessage());
+
+        self::assertSame($validationError4->getTarget(), $errors[3]->getTarget());
+        self::assertSame((string) $validationError4->getTranslatableMessage(), (string) $errors[3]->getTranslatableMessage());
     }
 
     public function testValidateFieldSettingsWithInvalidOptionsInFieldSettings(): void
@@ -267,6 +278,7 @@ final class TypeTest extends TestCase
                 [
                     'name' => false,
                     'identifier' => false,
+                    'language_code' => false,
                     'priority' => 'test',
                 ],
             ],
@@ -301,6 +313,14 @@ final class TypeTest extends TestCase
         );
 
         $validationError4 = new ValidationError(
+            "'%setting%' setting value item's 'language_code' property must be of string value",
+            null,
+            [
+                '%setting%' => 'options',
+            ]
+        );
+
+        $validationError5 = new ValidationError(
             "'%setting%' setting value item's 'priority' property must be of numeric value",
             null,
             [
@@ -321,6 +341,9 @@ final class TypeTest extends TestCase
 
         self::assertSame($validationError4->getTarget(), $errors[3]->getTarget());
         self::assertSame((string) $validationError4->getTranslatableMessage(), (string) $errors[3]->getTranslatableMessage());
+
+        self::assertSame($validationError5->getTarget(), $errors[4]->getTarget());
+        self::assertSame((string) $validationError5->getTranslatableMessage(), (string) $errors[4]->getTranslatableMessage());
     }
 
     public function testAcceptValueWithSingle(): void

--- a/tests/Core/Persistence/Legacy/Content/FieldValue/Converter/EnhancedSelectionConverterTest.php
+++ b/tests/Core/Persistence/Legacy/Content/FieldValue/Converter/EnhancedSelectionConverterTest.php
@@ -63,6 +63,7 @@ final class EnhancedSelectionConverterTest extends TestCase
                 [
                     'name' => 'name',
                     'identifier' => 'id',
+                    'language_code' => 'cro-HR',
                     'priority' => 10,
                 ],
             ],
@@ -79,7 +80,7 @@ final class EnhancedSelectionConverterTest extends TestCase
         $fieldDefinition = new FieldDefinition();
         $storageDefinition = new StorageFieldDefinition();
         $storageDefinition->dataText5 = '<?xml version="1.0"?>
-            <content><options><option id="3" name="None" identifier="none" priority="0"/><option id="1" name="Include" identifier="include" priority="1"/><option id="2" name="Exclude" identifier="exclude" priority="2"/></options><multiselect>1</multiselect><expanded>1</expanded><delimiter><![CDATA[]]></delimiter><query><![CDATA[]]></query></content>';
+            <content><options><option id="3" name="None" identifier="none" langauge_code="cro-HR" priority="0"/><option id="1" name="Include" identifier="include" langauge_code="cro-HR" priority="1"/><option id="2" name="Exclude" identifier="exclude" langauge_code="cro-HR" priority="2"/></options><multiselect>1</multiselect><expanded>1</expanded><delimiter><![CDATA[]]></delimiter><query><![CDATA[]]></query></content>';
 
         $this->converter->toFieldDefinition($storageDefinition, $fieldDefinition);
     }


### PR DESCRIPTION
This adds a dropdown for every option in field definition with enabled languages in the system.

The point of this change is to allow translation of selection labels. Identifier uniqueness is not checked, since now we can have multiple options with the same identifier for multiple translations.

![image](https://github.com/netgen/NetgenEnhancedSelectionBundle/assets/362286/6b6680ce-2a82-42fd-9b09-b22d1be88d16)

Data migration is not needed since existing options without a language code (or with empty language code) are presumed to be available in all languages.