### PR TITLE
NGSTACK-922 remove jquery

### DIFF
--- a/bundle/Resources/public/admin/js/init.js
+++ b/bundle/Resources/public/admin/js/init.js
@@ -1,41 +1,54 @@
-(function($) {
-    'use strict';
-    $('.multientry').multientry();
+const init = () => {
+  window.initaliseMultientries();
 
-    const saveButton = document.getElementById('content_type_edit__sidebar_right__save-tab');
+  const observer = new MutationObserver(() => {
+    window.initaliseMultientries();
+  });
 
-    const observer = new MutationObserver(e => {
-        $('.multientry').multientry();
+  // enables observer when element is dropped
+  document.addEventListener('drop', () => {
+    document.querySelectorAll('.ibexa-collapse').forEach((element) => {
+      observer.observe(element, { childList: true, subtree: true });
     });
+  });
 
-    // enables observer when elements is dropped
-    document.addEventListener("drop", e => {
-        document.querySelectorAll('.ibexa-collapse').forEach(el => {
-            observer.observe(el, { childList: true, subtree: true });
-        });
+  // disable observer while dragging to reduce function firing
+  document.addEventListener('drag', () => {
+    document.querySelectorAll('.ibexa-collapse').forEach(() => {
+      observer.disconnect();
     });
+  });
 
-    // disable observer while dragging to reduce function firing
-    document.addEventListener("drag", e => {
-        document.querySelectorAll('.ibexa-collapse').forEach(el => {
-            observer.disconnect();
-        });
-    });
+  // checks if any multientry inputs are empty and expands the field type
+  const saveButton = document.getElementById('content_type_edit__sidebar_right__save-tab');
 
-    // checks if any multientry inputs are empty and expands the field type
-    saveButton && saveButton.addEventListener("click", e => {
-        document.querySelectorAll('.multientry input').forEach(el => {
-            if (el.value.length === 0) {
-                e.preventDefault();
-                const fullElement = el.closest('.ibexa-collapse');
-                const elementBody = fullElement.querySelector('.ibexa-collapse__body');
-                const collapseToggle = fullElement.querySelector('.ibexa-collapse__toggle-btn');
-                fullElement.classList.contains('multientry-error') ? null : fullElement.classList.add('multientry-error');
-                fullElement.classList.contains('ibexa-collapse--collapsed') ? fullElement.classList.remove('ibexa-collapse--collapsed') : null;
-                elementBody.classList.contains('show') ? null : elementBody.classList.add('show');
-                collapseToggle.classList.contains('collapsed') ? elementBody.classList.remove('collapsed') : null;
-                fullElement.dataset.collapsed ? fullElement.dataset.collapsed = false : null;
-            }
-        })
+  saveButton && saveButton.addEventListener('click', (event) => {
+    document.querySelectorAll('.multientry input').forEach((input) => {
+      if (input.value.length > 0) {
+        return;
+      }
+
+      event.preventDefault();
+
+      const collapseWrapper = input.closest('.ibexa-collapse');
+      const collapseBody = collapseWrapper.querySelector('.ibexa-collapse__body');
+      const collapseToggle = collapseWrapper.querySelector('.ibexa-collapse__toggle-btn');
+
+      collapseWrapper.classList.add('multientry-error');
+      collapseWrapper.classList.remove('ibexa-collapse--collapsed');
+      collapseWrapper.dataset.collapsed = false;
+
+      collapseBody.classList.add('show');
+
+      if (collapseToggle.classList.contains('collapsed')) {
+        collapseBody.classList.remove('collapsed');
+      }
     });
-})(jQuery);
+  });
+};
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init);
+} else {
+  init();
+}

--- a/bundle/Resources/public/admin/js/multientry.js
+++ b/bundle/Resources/public/admin/js/multientry.js
@@ -168,9 +168,9 @@ class MultiEntry {
 
   static create_element_from_string(elementString) {
     const template = document.createElement('template');
-    template.innerHTML = elementString;
+    template.innerHTML = elementString.trim();
 
-    return template.content.firstElementChild;
+    return template.content.firstChild;
   }
 }
 

--- a/bundle/Resources/public/admin/js/multientry.js
+++ b/bundle/Resources/public/admin/js/multientry.js
@@ -43,15 +43,16 @@ class MultiEntry {
       ...externalOptions,
     };
 
+    this.$add_button = this.$element.querySelector(SELECTORS.add_button);
     this.$items_container = this.$element.querySelector(SELECTORS.items_container);
     this.items_exist = !!this.$items_container.querySelector(SELECTORS.item);
+
     this.item_template = this.$element.dataset.prototype;
+    this.remove_button_template = '<i class="icon-close"></i>';
 
     this.$error = MultiEntry.create_element_from_string(
       `<div class="multientry-error">${this.options.error_message}</div>`
     );
-    this.$add_button = this.$element.querySelector(SELECTORS.add_button);
-    this.$remove_element = MultiEntry.create_element_from_string('<i class="icon-close"></i>');
 
     this.setup_dom();
     this.setup_events();
@@ -73,7 +74,7 @@ class MultiEntry {
       this.item_template.replace(/__name__/g, this.next_id())
     );
     $template.classList.add('multientry-item', 'new');
-    $template.append(this.$remove_element);
+    $template.append(MultiEntry.create_element_from_string(this.remove_button_template));
 
     $template.querySelector(SELECTORS.remove_button).addEventListener('click', () => {
       this.remove($template);
@@ -84,7 +85,7 @@ class MultiEntry {
 
   setup_dom() {
     this.$element.querySelectorAll(SELECTORS.item).forEach(($item) => {
-      $item.append(this.$remove_element);
+      $item.append(MultiEntry.create_element_from_string(this.remove_button_template));
     });
   }
 

--- a/bundle/Resources/public/admin/js/multientry.js
+++ b/bundle/Resources/public/admin/js/multientry.js
@@ -72,10 +72,10 @@ class MultiEntry {
     const $template = MultiEntry.create_element_from_string(
       this.item_template.replace(/__name__/g, this.next_id())
     );
-    $template.classList.add('multientry-item new');
+    $template.classList.add('multientry-item', 'new');
     $template.append(this.$remove_element);
 
-    $template.querySelector(SELECTORS.close_button).addEventListener('click', () => {
+    $template.querySelector(SELECTORS.remove_button).addEventListener('click', () => {
       this.remove($template);
     });
 
@@ -166,7 +166,10 @@ class MultiEntry {
   }
 
   static create_element_from_string(elementString) {
-    return this.parser.parseFromString(elementString).querySelector('body > *');
+    const template = document.createElement('template');
+    template.innerHTML = elementString;
+
+    return template.content.firstElementChild;
   }
 }
 


### PR DESCRIPTION
Changes
---
- removed all usages of jquery
- functions exposed globally in window
- kept the possibility of calling a method on all instances, but through a different function for clarity
- cleaned up some code like the ternaries removing and adding classes
- keeping track of existing instances based on instanceId passed during creation (last index of instances array)
  - old way was setting jquery data on jquery elements
- creating new elements by creating a `template` element and setting its `innerHTML` to the trimmed template string, then reading `content.firstChild`
  - requires the string to have a single root element, but the code in general relies on there being a single wrapper for each item anyway
  - old way was just passing a string to jquery and letting it handle that
- events are now CustomEvents, still dispatched from body and the element triggering them
  - I am not sure if this makes some difference compared to the events sent out by jquery, not sure where these are listened to and used

Note
---
- I am uncertain how options work because the init file does not contain any options to initialise the elements with (nothing was passed even before to the jquery function)
- if there is a limit, the add button is not really disabled from what I can see, the disabled behaviour is handled through code (was that way before), just has a class for the visuals I suppose

Testing
---
- have a media-site (ibexa) project with the bundle installed
- if tags bundle is installed
  - from `vendor/netgen/tagsbundle/bundle/Resources/config/ibexa/admin/services.yaml` remove `netgen_tags.ibexa.admin.component.javascripts` config
- clone this repo in place of `vendor/netgen/enhanced-selection-bundle`
- checkout `NGSTACK-922-remove-jquery`
- clear cache
- if possible or needed, test some options through `data-*` parameters (the names are like `data-error_message`, see the underscore in the name after the usual `data-` prefix)
- in the admin, try to edit ng_category
  - should have no enhanced-selection related errors in the console, esp not jquery
  - add/remove items from a `sckenhancedselection` field
  - add new `sckenhancedselection` fields
  - save with empty fields to trigger errors
  - collapse with empty fields and save - should uncollapse