### PR TITLE
NGSTACK-995 upgrade bundle to ibexa 5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,15 +15,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4', '8.0', '8.1']
-        symfony: ['~5.4.0']
+        php: ['8.3']
+        symfony: ['~7.3.0']
         phpunit: ['phpunit.xml']
         deps: ['normal']
-        include:
-          - php: '7.4'
-            symfony: '~5.4.0'
-            phpunit: 'phpunit.xml'
-            deps: 'low'
 
     steps:
       - uses: actions/checkout@v2

--- a/bundle/Command/MigrateCommand.php
+++ b/bundle/Command/MigrateCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Netgen\Bundle\EnhancedSelectionBundle\Command;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Driver\Result;
+use Doctrine\DBAL\Result;
 use Netgen\Bundle\EnhancedSelectionBundle\Core\FieldType\EnhancedSelection\Type as EnhancedSelectionType;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -42,7 +42,7 @@ final class MigrateCommand extends Command
         $this->io = new SymfonyStyle($input, $output);
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output): ?int
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $statement = $this->getFields();
         $this->io->progressStart($statement->rowCount());
@@ -80,7 +80,7 @@ final class MigrateCommand extends Command
             )
             ->setParameter('data_type_string', $this->typeIdentifier);
 
-        return $builder->execute();
+        return $builder->executeQuery();
     }
 
     private function resetFieldData(int $id, int $version): void
@@ -96,7 +96,7 @@ final class MigrateCommand extends Command
             ->setParameter('id', $id)
             ->setParameter('version', $version);
 
-        $builder->execute();
+        $builder->executeStatement();
     }
 
     private function removeSelectionDataForField(int $id, int $version): void
@@ -111,7 +111,7 @@ final class MigrateCommand extends Command
             ->setParameter('id', $id)
             ->setParameter('version', $version);
 
-        $builder->execute();
+        $builder->executeStatement();
     }
 
     private function createSelections(int $id, int $version, array $identifiers): void

--- a/bundle/Core/FieldType/EnhancedSelection/EnhancedSelectionStorage.php
+++ b/bundle/Core/FieldType/EnhancedSelection/EnhancedSelectionStorage.php
@@ -7,10 +7,17 @@ namespace Netgen\Bundle\EnhancedSelectionBundle\Core\FieldType\EnhancedSelection
 use Ibexa\Contracts\Core\FieldType\GatewayBasedStorage;
 use Ibexa\Contracts\Core\Persistence\Content\Field;
 use Ibexa\Contracts\Core\Persistence\Content\VersionInfo;
+use Netgen\Bundle\EnhancedSelectionBundle\Core\FieldType\EnhancedSelection\EnhancedSelectionStorage\Gateway;
 
 final class EnhancedSelectionStorage extends GatewayBasedStorage
 {
-    public function storeFieldData(VersionInfo $versionInfo, Field $field, array $context): ?bool
+    public function __construct(Gateway $gateway)
+    {
+        $this->gateway = $gateway;
+        parent::__construct($gateway);
+    }
+
+    public function storeFieldData(VersionInfo $versionInfo, Field $field): ?bool
     {
         $this->gateway->deleteFieldData($versionInfo, [$field->id]);
         if (!empty($field->value->externalData)) {
@@ -20,12 +27,12 @@ final class EnhancedSelectionStorage extends GatewayBasedStorage
         return null;
     }
 
-    public function getFieldData(VersionInfo $versionInfo, Field $field, array $context): void
+    public function getFieldData(VersionInfo $versionInfo, Field $field): void
     {
         $this->gateway->getFieldData($versionInfo, $field);
     }
 
-    public function deleteFieldData(VersionInfo $versionInfo, array $fieldIds, array $context): bool
+    public function deleteFieldData(VersionInfo $versionInfo, array $fieldIds): bool
     {
         $this->gateway->deleteFieldData($versionInfo, $fieldIds);
 
@@ -37,7 +44,7 @@ final class EnhancedSelectionStorage extends GatewayBasedStorage
         return true;
     }
 
-    public function getIndexData(VersionInfo $versionInfo, Field $field, array $context)
+    public function getIndexData(VersionInfo $versionInfo, Field $field): bool
     {
         return false;
     }

--- a/bundle/Core/FieldType/EnhancedSelection/EnhancedSelectionStorage.php
+++ b/bundle/Core/FieldType/EnhancedSelection/EnhancedSelectionStorage.php
@@ -7,16 +7,9 @@ namespace Netgen\Bundle\EnhancedSelectionBundle\Core\FieldType\EnhancedSelection
 use Ibexa\Contracts\Core\FieldType\GatewayBasedStorage;
 use Ibexa\Contracts\Core\Persistence\Content\Field;
 use Ibexa\Contracts\Core\Persistence\Content\VersionInfo;
-use Netgen\Bundle\EnhancedSelectionBundle\Core\FieldType\EnhancedSelection\EnhancedSelectionStorage\Gateway;
 
 final class EnhancedSelectionStorage extends GatewayBasedStorage
 {
-    public function __construct(Gateway $gateway)
-    {
-        $this->gateway = $gateway;
-        parent::__construct($gateway);
-    }
-
     public function storeFieldData(VersionInfo $versionInfo, Field $field): ?bool
     {
         $this->gateway->deleteFieldData($versionInfo, [$field->id]);

--- a/bundle/Core/FieldType/EnhancedSelection/EnhancedSelectionStorage/Gateway/DoctrineStorage.php
+++ b/bundle/Core/FieldType/EnhancedSelection/EnhancedSelectionStorage/Gateway/DoctrineStorage.php
@@ -38,7 +38,7 @@ final class DoctrineStorage extends Gateway
                 ->setParameter(':contentobject_attribute_version', $versionInfo->versionNo, Types::INTEGER)
                 ->setParameter(':identifier', $identifier, Types::STRING);
 
-            $insertQuery->execute();
+            $insertQuery->executeStatement();
         }
     }
 
@@ -61,7 +61,7 @@ final class DoctrineStorage extends Gateway
             ->setParameter(':contentobject_attribute_id', $fieldIds, Connection::PARAM_INT_ARRAY)
             ->setParameter(':contentobject_attribute_version', $versionInfo->versionNo, Types::INTEGER);
 
-        $query->execute();
+        $query->executeStatement();
     }
 
     /**
@@ -84,9 +84,7 @@ final class DoctrineStorage extends Gateway
             ->setParameter(':contentobject_attribute_id', $fieldId, Types::INTEGER)
             ->setParameter(':contentobject_attribute_version', $versionNo, Types::INTEGER);
 
-        $statement = $query->execute();
-
-        $rows = $statement->fetchAllAssociative();
+        $rows = $query->executeQuery()->fetchAllAssociative();
 
         return array_map(
             static fn (array $row): string => $row['identifier'],

--- a/bundle/Core/FieldType/EnhancedSelection/EnhancedSelectionStorage/Gateway/DoctrineStorage.php
+++ b/bundle/Core/FieldType/EnhancedSelection/EnhancedSelectionStorage/Gateway/DoctrineStorage.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Netgen\Bundle\EnhancedSelectionBundle\Core\FieldType\EnhancedSelection\EnhancedSelectionStorage\Gateway;
 
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Types;
 use Ibexa\Contracts\Core\Persistence\Content\Field;
@@ -34,9 +35,9 @@ final class DoctrineStorage extends Gateway
                         'identifier' => ':identifier',
                     ]
                 )
-                ->setParameter(':contentobject_attribute_id', $field->id, Types::INTEGER)
-                ->setParameter(':contentobject_attribute_version', $versionInfo->versionNo, Types::INTEGER)
-                ->setParameter(':identifier', $identifier, Types::STRING);
+                ->setParameter('contentobject_attribute_id', $field->id, Types::INTEGER)
+                ->setParameter('contentobject_attribute_version', $versionInfo->versionNo, Types::INTEGER)
+                ->setParameter('identifier', $identifier, Types::STRING);
 
             $insertQuery->executeStatement();
         }
@@ -54,12 +55,12 @@ final class DoctrineStorage extends Gateway
             ->delete($this->connection->quoteIdentifier('sckenhancedselection'))
             ->where(
                 $query->expr()->and(
-                    $query->expr()->in('contentobject_attribute_id', [':contentobject_attribute_id']),
+                    $query->expr()->in('contentobject_attribute_id', ':contentobject_attribute_id'),
                     $query->expr()->eq('contentobject_attribute_version', ':contentobject_attribute_version')
                 )
             )
-            ->setParameter(':contentobject_attribute_id', $fieldIds, Connection::PARAM_INT_ARRAY)
-            ->setParameter(':contentobject_attribute_version', $versionInfo->versionNo, Types::INTEGER);
+            ->setParameter('contentobject_attribute_id', $fieldIds, ArrayParameterType::INTEGER)
+            ->setParameter('contentobject_attribute_version', $versionInfo->versionNo, Types::INTEGER);
 
         $query->executeStatement();
     }
@@ -81,8 +82,8 @@ final class DoctrineStorage extends Gateway
                     $query->expr()->eq('contentobject_attribute_version', ':contentobject_attribute_version')
                 )
             )
-            ->setParameter(':contentobject_attribute_id', $fieldId, Types::INTEGER)
-            ->setParameter(':contentobject_attribute_version', $versionNo, Types::INTEGER);
+            ->setParameter('contentobject_attribute_id', $fieldId, Types::INTEGER)
+            ->setParameter('contentobject_attribute_version', $versionNo, Types::INTEGER);
 
         $rows = $query->executeQuery()->fetchAllAssociative();
 

--- a/bundle/Core/FieldType/EnhancedSelection/Type.php
+++ b/bundle/Core/FieldType/EnhancedSelection/Type.php
@@ -316,9 +316,9 @@ final class Type extends FieldType
 
                         if ($emptyCount > ($fieldSettings['isMultiple'] ? 0 : 1)) {
                             $validationErrors[] = new ValidationError(
-                                $fieldSettings['isMultiple'] ?
-                                    "'%setting%' setting value item's 'identifier' property must have a value" :
-                                    "'%setting%' setting value item's 'identifier' property must have only a single empty value",
+                                $fieldSettings['isMultiple']
+                                    ? "'%setting%' setting value item's 'identifier' property must have a value"
+                                    : "'%setting%' setting value item's 'identifier' property must have only a single empty value",
                                 null,
                                 [
                                     '%setting%' => $name,

--- a/bundle/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/EnhancedSelection.php
+++ b/bundle/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/EnhancedSelection.php
@@ -20,7 +20,7 @@ final class EnhancedSelection extends FieldBase
     }
 
     /**
-     * @param Netgen\Bundle\EnhancedSelectionBundle\API\Repository\Values\Content\Query\Criterion\EnhancedSelection $criterion
+     * @param \Netgen\Bundle\EnhancedSelectionBundle\API\Repository\Values\Content\Query\Criterion\EnhancedSelection $criterion
      */
     public function handle(
         CriteriaConverter $converter,

--- a/bundle/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/EnhancedSelection.php
+++ b/bundle/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/EnhancedSelection.php
@@ -6,7 +6,7 @@ namespace Netgen\Bundle\EnhancedSelectionBundle\Core\Search\Legacy\Content\Commo
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
-use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
 use Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldBase;
@@ -14,13 +14,27 @@ use Netgen\Bundle\EnhancedSelectionBundle\API\Repository\Values\Content\Query\Cr
 
 final class EnhancedSelection extends FieldBase
 {
-    public function accept(Criterion $criterion): bool
+    public function accept(CriterionInterface $criterion): bool
     {
         return $criterion instanceof EnhancedSelectionCriterion;
     }
 
-    public function handle(CriteriaConverter $converter, QueryBuilder $queryBuilder, Criterion $criterion, array $languageSettings): string
-    {
+    /**
+     * @param CriteriaConverter $converter
+     * @param QueryBuilder $queryBuilder
+     * @param EnhancedSelectionCriterion $criterion
+     * @param array $languageSettings
+     *
+     * @return string
+     *
+     * @throws InvalidArgumentException
+     */
+    public function handle(
+        CriteriaConverter $converter,
+        QueryBuilder $queryBuilder,
+        CriterionInterface $criterion,
+        array $languageSettings,
+    ): string {
         $fieldDefinitionIds = $this->getFieldDefinitionIds($criterion->target);
 
         $subSelect = $this->connection->createQueryBuilder();

--- a/bundle/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/EnhancedSelection.php
+++ b/bundle/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/EnhancedSelection.php
@@ -20,14 +20,7 @@ final class EnhancedSelection extends FieldBase
     }
 
     /**
-     * @param CriteriaConverter $converter
-     * @param QueryBuilder $queryBuilder
-     * @param EnhancedSelectionCriterion $criterion
-     * @param array $languageSettings
-     *
-     * @return string
-     *
-     * @throws InvalidArgumentException
+     * @param Netgen\Bundle\EnhancedSelectionBundle\API\Repository\Values\Content\Query\Criterion\EnhancedSelection $criterion
      */
     public function handle(
         CriteriaConverter $converter,

--- a/bundle/Core/Search/Solr/Query/CriterionVisitor/EnhancedSelection.php
+++ b/bundle/Core/Search/Solr/Query/CriterionVisitor/EnhancedSelection.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Netgen\Bundle\EnhancedSelectionBundle\Core\Search\Solr\Query\CriterionVisitor;
 
-use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface;
 use Ibexa\Contracts\Solr\Query\CriterionVisitor;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
 use Ibexa\Solr\Query\Common\CriterionVisitor\Field;
@@ -14,12 +14,17 @@ use function implode;
 
 final class EnhancedSelection extends Field
 {
-    public function canVisit(Criterion $criterion): bool
+    public function canVisit(CriterionInterface $criterion): bool
     {
         return $criterion instanceof EnhancedSelectionCriterion;
     }
 
-    public function visit(Criterion $criterion, ?CriterionVisitor $subVisitor = null): string
+    /**
+     * @param EnhancedSelectionCriterion $criterion
+     *
+     * @throws InvalidArgumentException
+     */
+    public function visit(CriterionInterface $criterion, ?CriterionVisitor $subVisitor = null): string
     {
         $searchFields = $this->getSearchFields($criterion);
 

--- a/bundle/Core/Search/Solr/Query/CriterionVisitor/EnhancedSelection.php
+++ b/bundle/Core/Search/Solr/Query/CriterionVisitor/EnhancedSelection.php
@@ -20,9 +20,9 @@ final class EnhancedSelection extends Field
     }
 
     /**
-     * @param Netgen\Bundle\EnhancedSelectionBundle\API\Repository\Values\Content\Query\Criterion\EnhancedSelection $criterion
+     * @param \Netgen\Bundle\EnhancedSelectionBundle\API\Repository\Values\Content\Query\Criterion\EnhancedSelection $criterion
      *
-     * @throws Ibexa\Core\Base\Exceptions\InvalidArgumentException
+     * @throws \Ibexa\Core\Base\Exceptions\InvalidArgumentException
      */
     public function visit(CriterionInterface $criterion, ?CriterionVisitor $subVisitor = null): string
     {

--- a/bundle/Core/Search/Solr/Query/CriterionVisitor/EnhancedSelection.php
+++ b/bundle/Core/Search/Solr/Query/CriterionVisitor/EnhancedSelection.php
@@ -20,9 +20,9 @@ final class EnhancedSelection extends Field
     }
 
     /**
-     * @param EnhancedSelectionCriterion $criterion
+     * @param Netgen\Bundle\EnhancedSelectionBundle\API\Repository\Values\Content\Query\Criterion\EnhancedSelection $criterion
      *
-     * @throws InvalidArgumentException
+     * @throws Ibexa\Core\Base\Exceptions\InvalidArgumentException
      */
     public function visit(CriterionInterface $criterion, ?CriterionVisitor $subVisitor = null): string
     {

--- a/bundle/Form/Type/FieldType/FieldValueTransformer.php
+++ b/bundle/Form/Type/FieldType/FieldValueTransformer.php
@@ -47,9 +47,9 @@ final class FieldValueTransformer implements DataTransformerInterface
             return $this->fieldType->getEmptyValue();
         }
 
-        $hash = is_array($value['identifiers']) ?
-            $value['identifiers'] :
-            [$value['identifiers']];
+        $hash = is_array($value['identifiers'])
+            ? $value['identifiers']
+            : [$value['identifiers']];
 
         return $this->fieldType->fromHash($hash);
     }

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",
-        "netgen/ibexa-forms-bundle": "^4.0",
         "friendsofphp/php-cs-fixer": "^3.3",
         "ibexa/solr": "^5.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,15 @@
         }
     ],
     "require": {
-        "ibexa/core": "^4.0",
-        "ibexa/content-forms": "^4.0",
+        "ibexa/core": "^5.0",
+        "ibexa/content-forms": "^5.0",
         "twig/twig": "^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",
         "netgen/ibexa-forms-bundle": "^4.0",
-        "friendsofphp/php-cs-fixer": "^3.3"
+        "friendsofphp/php-cs-fixer": "^3.3",
+        "ibexa/solr": "^5.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",
+        "netgen/ibexa-forms-bundle": "^5.0",
         "friendsofphp/php-cs-fixer": "^3.3",
         "ibexa/solr": "^5.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "twig/twig": "^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0",
+        "phpunit/phpunit": "^12.0",
         "netgen/ibexa-forms-bundle": "^5.0",
         "friendsofphp/php-cs-fixer": "^3.3",
         "ibexa/solr": "^5.0"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="vendor/autoload.php"
          backupGlobals="false"
          backupStaticAttributes="false"
          convertErrorsToExceptions="true"
@@ -10,29 +11,31 @@
          processIsolation="false"
          stopOnFailure="false"
          beStrictAboutTestsThatDoNotTestAnything="false"
->
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    <coverage>
+        <include>
+            <directory suffix=".php">bundle</directory>
+        </include>
+        <exclude>
+            <directory>bundle/DependencyInjection</directory>
+            <directory>bundle/Resources</directory>
+            <directory>vendor</directory>
+            <file>bundle/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/EnhancedSelection.php</file>
+            <file>bundle/Core/FieldType/EnhancedSelection/SearchField.php</file>
+            <file>bundle/NetgenEnhancedSelectionBundle.php</file>
+        </exclude>
+        <report>
+            <clover outputFile="build/logs/clover.xml"/>
+            <html outputDirectory="build/coverage"/>
+            <text outputFile="build/coverage.txt"/>
+        </report>
+    </coverage>
     <testsuites>
         <testsuite name="Netgen\EnhancedSelectionBundle\Tests">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">bundle</directory>
-            <exclude>
-                <directory>bundle/DependencyInjection</directory>
-                <directory>bundle/Resources</directory>
-                <directory>vendor</directory>
-                <file>bundle/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/EnhancedSelection.php</file>
-                <file>bundle/Core/FieldType/EnhancedSelection/SearchField.php</file>
-                <file>bundle/NetgenEnhancedSelectionBundle.php</file>
-            </exclude>
-        </whitelist>
-    </filter>
     <logging>
-        <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage"/>
-        <log type="coverage-text" target="build/coverage.txt"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
+        <junit outputFile="build/report.junit.xml"/>
     </logging>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,17 +2,25 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          bootstrap="vendor/autoload.php"
          backupGlobals="false"
-         backupStaticAttributes="false"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          colors="true"
-         verbose="true"
          processIsolation="false"
          stopOnFailure="false"
          beStrictAboutTestsThatDoNotTestAnything="false"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-    <coverage>
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.4/phpunit.xsd"
+         cacheDirectory=".phpunit.cache"
+         backupStaticProperties="false"
+>
+    <testsuites>
+        <testsuite name="Netgen\EnhancedSelectionBundle\Tests">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <logging>
+        <junit outputFile="build/report.junit.xml"/>
+    </logging>
+
+    <source>
         <include>
             <directory suffix=".php">bundle</directory>
         </include>
@@ -24,18 +32,5 @@
             <file>bundle/Core/FieldType/EnhancedSelection/SearchField.php</file>
             <file>bundle/NetgenEnhancedSelectionBundle.php</file>
         </exclude>
-        <report>
-            <clover outputFile="build/logs/clover.xml"/>
-            <html outputDirectory="build/coverage"/>
-            <text outputFile="build/coverage.txt"/>
-        </report>
-    </coverage>
-    <testsuites>
-        <testsuite name="Netgen\EnhancedSelectionBundle\Tests">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <junit outputFile="build/report.junit.xml"/>
-    </logging>
+    </source>
 </phpunit>

--- a/tests/Core/FieldType/EnhancedSelection/EnhancedSelectionStorageTest.php
+++ b/tests/Core/FieldType/EnhancedSelection/EnhancedSelectionStorageTest.php
@@ -60,7 +60,7 @@ final class EnhancedSelectionStorageTest extends TestCase
             ]
         );
 
-        $connection = $this->getMockForAbstractClass(StorageGateway::class);
+        $connection = $this->createMock(StorageGateway::class);
         $context = ['identifier' => 'enhancedselection', 'connection' => $connection];
 
         $this->gateway->expects(self::once())
@@ -86,7 +86,7 @@ final class EnhancedSelectionStorageTest extends TestCase
             ]
         );
 
-        $connection = $this->getMockForAbstractClass(StorageGateway::class);
+        $connection = $this->createMock(StorageGateway::class);
         $context = ['identifier' => 'enhancedselection', 'connection' => $connection];
 
         $this->gateway->expects(self::once())
@@ -100,7 +100,7 @@ final class EnhancedSelectionStorageTest extends TestCase
         $versionInfo = new VersionInfo();
         $fields = ['some_field'];
 
-        $connection = $this->getMockForAbstractClass(StorageGateway::class);
+        $connection = $this->createMock(StorageGateway::class);
         $context = ['identifier' => 'enhancedselection', 'connection' => $connection];
 
         $this->gateway->expects(self::once())

--- a/tests/Core/FieldType/EnhancedSelection/EnhancedSelectionStorageTest.php
+++ b/tests/Core/FieldType/EnhancedSelection/EnhancedSelectionStorageTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Netgen\Bundle\EnhancedSelectionBundle\Tests\Core\FieldType\EnhancedSelection;
 
+use Ibexa\Contracts\Core\FieldType\StorageGateway;
 use Ibexa\Contracts\Core\Persistence\Content\Field;
 use Ibexa\Contracts\Core\Persistence\Content\FieldValue;
 use Ibexa\Contracts\Core\Persistence\Content\VersionInfo;
-use Ibexa\Core\FieldType\StorageGateway;
 use Netgen\Bundle\EnhancedSelectionBundle\Core\FieldType\EnhancedSelection\EnhancedSelectionStorage;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -43,7 +43,7 @@ final class EnhancedSelectionStorageTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        self::assertFalse($this->storage->getIndexData($versionInfo, $field, []));
+        self::assertFalse($this->storage->getIndexData($versionInfo, $field));
     }
 
     public function testStoreFieldData(): void

--- a/tests/Core/FieldType/EnhancedSelection/TypeTest.php
+++ b/tests/Core/FieldType/EnhancedSelection/TypeTest.php
@@ -375,8 +375,6 @@ final class TypeTest extends TestCase
     {
         $this->expectException(InvalidArgumentType::class);
 
-        $value = new Value([true, true]);
-
-        $this->type->acceptValue($value);
+        $this->type->acceptValue([true, true]);
     }
 }

--- a/tests/Form/FieldTypeHandler/EnhancedSelectionTest.php
+++ b/tests/Form/FieldTypeHandler/EnhancedSelectionTest.php
@@ -108,7 +108,7 @@ final class EnhancedSelectionTest extends TestCase
 
         $fieldDefinition = new FieldDefinition(
             [
-                'id' => 'id',
+                'id' => 11,
                 'identifier' => 'identifier',
                 'isRequired' => true,
                 'descriptions' => ['fre-FR' => 'fre-FR'],

--- a/tests/Templating/Twig/NetgenEnhancedSelectionRuntimeTest.php
+++ b/tests/Templating/Twig/NetgenEnhancedSelectionRuntimeTest.php
@@ -25,10 +25,7 @@ final class NetgenEnhancedSelectionRuntimeTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->contentTypeService = $this->getMockBuilder(ContentTypeService::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['loadContentType'])
-            ->getMockForAbstractClass();
+        $this->contentTypeService = $this->createMock(ContentTypeService::class);
 
         $this->runtime = new NetgenEnhancedSelectionRuntime($this->contentTypeService);
     }


### PR DESCRIPTION
Updated the whole bundle to use Ibexa v5. Fixed a few small things - mostly changed some method definitions and updated database gateway. 

Also, I've removed the **ibexa-forms-bundle** from _require-dev_ section and included **ibexa/solr** bundle there because it is used in `bundle/Core/Search/Solr/Query/CriterionVisitor/EnhancedSelection.php` file. 

In `tests.yml` file (used for GitHub Actions), the PHP version has been updated to 8.3 and Symfony version to 7.3. Right now, the tests are failing because the **ibexa-forms-bundle** is removed from `composer.json` file.